### PR TITLE
Refactor site with semantic, keyboard-friendly design

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,19 +1,58 @@
-<!Doctype HTML>
-<html>
-  <body>
-  <P></P>
-</body>
-</html>
-
-<!doctype html>
-<html lang="eng">
+<!DOCTYPE html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Interweb Stellar LLC</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Accessible Web Experience</title>
+  <meta name="description" content="Accessible, responsive website built with WCAG guidelines in mind.">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <p>Affordable rapid web-designs and seamless communication and support.</p>
-<p><i>A small business that gets your small business.</i></p>
-  <button>big</button>
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <header>
+    <h1>Accessible Web Experience</h1>
+    <nav aria-label="Primary">
+      <ul>
+        <li><a href="#about">About</a></li>
+        <li><a href="#services">Services</a></li>
+        <li><a href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main id="main">
+    <section id="about">
+      <h2>About</h2>
+      <p>We craft inclusive, performant websites that welcome every visitor. Our design process centers around accessibility from day one.</p>
+    </section>
+    <section id="services">
+      <h2>Services</h2>
+      <article>
+        <h3>Responsive Design</h3>
+        <p>Layouts that look great on any device without sacrificing usability or speed.</p>
+      </article>
+      <article>
+        <h3>Accessibility Audits</h3>
+        <p>Thorough evaluations to ensure your site meets WCAG guidelines and delivers a smooth experience for all users.</p>
+      </article>
+    </section>
+    <section id="contact">
+      <h2>Contact</h2>
+      <form action="#" method="post">
+        <fieldset>
+          <legend>Send us a message</legend>
+          <label for="name">Name</label>
+          <input id="name" name="name" type="text" required>
+          <label for="email">Email</label>
+          <input id="email" name="email" type="email" required>
+          <label for="message">Message</label>
+          <textarea id="message" name="message" rows="5" required></textarea>
+          <button type="submit">Send</button>
+        </fieldset>
+      </form>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2024 Accessible Web Experience. All rights reserved.</p>
+  </footer>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,108 @@
+/* Basic Reset */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+/* Focus styles */
+:focus-visible {
+  outline: 3px solid #005f73;
+  outline-offset: 2px;
+}
+
+/* Skip link */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: #005f73;
+  color: #fff;
+  padding: 8px 16px;
+  z-index: 100;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
+/* Layout and typography */
+body {
+  font-family: system-ui, sans-serif;
+  line-height: 1.6;
+  background: #f8f9fa;
+  color: #222;
+}
+
+header,
+main,
+footer {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+}
+
+nav a {
+  color: #005f73;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+nav a:hover,
+nav a:focus {
+  text-decoration: underline;
+}
+
+section + section {
+  margin-top: 2rem;
+}
+
+article + article {
+  margin-top: 1rem;
+}
+
+form {
+  display: grid;
+  gap: 0.5rem;
+  max-width: 400px;
+}
+
+input,
+textarea,
+button {
+  font: inherit;
+  padding: 0.5rem;
+}
+
+button {
+  background: #005f73;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+
+button:hover,
+button:focus {
+  background: #0a9396;
+}
+
+footer {
+  text-align: center;
+  margin-top: 2rem;
+  border-top: 1px solid #ccc;
+  padding-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- Rebuild site with semantic HTML structure and skip link for keyboard navigation
- Add accessible contact form and high-contrast styles

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bda7c7ac8325a73f3ce05e8d3130